### PR TITLE
Fix social replace

### DIFF
--- a/emergenceisbeautiful.html
+++ b/emergenceisbeautiful.html
@@ -159,17 +159,7 @@
 
     <script>
         $(document).ready(function() {
-            $("#social-icons").load("social.html", function() {
-                // Get the current page URL and title
-                var pageUrl = window.location.href;
-                var pageTitle = document.title;
-
-                // Replace placeholders in the loaded HTML
-                $(this).find("a").each(function() {
-                    this.href = this.href.replace('URL_PLACEHOLDER', encodeURIComponent(pageUrl));
-                    this.href = this.href.replace('TITLE_PLACEHOLDER', encodeURIComponent(pageTitle));
-                });
-            });
+            $("#social-icons").load("social.html");
         });
     </script>
 

--- a/index.html
+++ b/index.html
@@ -230,6 +230,16 @@
     </a>
     <br><br>Sharing good ideas is a win-win.<br><br>
 
+    <script type="text/javascript">
+        var pageUrl = window.location.href;
+        var pageTitle = document.title;
+        
+        $(".social-share").find("a").each(function() {
+            this.href = this.href.replace('URL_PLACEHOLDER', encodeURIComponent(pageUrl));
+            this.href = this.href.replace('TITLE_PLACEHOLDER', encodeURIComponent(pageTitle));
+        });
+    </script>
+
     <!-- Begin Mailchimp Subscribe Form -->
     <div id="mc_embed_signup"><br>
     <form action="https://games.us8.list-manage.com/subscribe/post?u=445e5215aca824f22b35f8f22&amp;id=f62bbfcd6b&amp;f_id=00bc60e0f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" style="text-align: center;">

--- a/social.html
+++ b/social.html
@@ -194,6 +194,16 @@
         <br>Sharing good ideas is a win-win. See you next week.<br>
         <p>—James :)</p>
 
+        <script type="text/javascript">
+            var pageUrl = window.location.href;
+            var pageTitle = document.title;
+            
+            $("#social-icons").find("a").each(function() {
+                this.href = this.href.replace('URL_PLACEHOLDER', encodeURIComponent(pageUrl));
+                this.href = this.href.replace('TITLE_PLACEHOLDER', encodeURIComponent(pageTitle));
+            });
+        </script>
+
     </div>
 
 <script>


### PR DESCRIPTION
It seems like the social links do not substitute placeholders. Here it works for a single post and the index file. Feel free to use/replicate if useful.